### PR TITLE
Add errno.h as include

### DIFF
--- a/lib/Application.cc
+++ b/lib/Application.cc
@@ -50,7 +50,7 @@
 #include <cstdlib>
 #include <string.h>
 #include <unistd.h>
-
+#include <errno.h>
 
 #if defined(__GNUC__)
 #  if __GNUC__ == 3 && __GNUC_MINOR__ == 3


### PR DESCRIPTION
Add errno.h as include in lib/Application.cc to avoid building error.

This will fix compilation error reported in #12 .