### PR TITLE
EWMH.cc needs cstdlib to compile on some OSes

### DIFF
--- a/lib/EWMH.cc
+++ b/lib/EWMH.cc
@@ -28,6 +28,7 @@
 #include <X11/Xlib.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 
 


### PR DESCRIPTION
Inclusion of cstdlib is needed as a build fix for NetBSD and other OSes.

(Example breakage on NetBSD:
`CXX      EWMH.lo
`EWMH.cc: In member function 'void bt::EWMH::setStartupId(Window, Window) const':
`EWMH.cc:799:41: error: 'getenv' was not declared in this scope
`   if (!(id = getenv("DESKTOP_STARTUP_ID")))
`                                         ^
`EWMH.cc:805:32: error: 'unsetenv' was not declared in this scope
`   unsetenv("DESKTOP_STARTUP_ID");
`                                ^
`*** Error code 1
`Stop.
)