### PR TITLE
Add missing include

### DIFF
--- a/lib/EWMH.cc
+++ b/lib/EWMH.cc
@@ -28,6 +28,7 @@
 #include <X11/Xlib.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 
 


### PR DESCRIPTION
If using a pre-C++11 standard, like C++98 or C++03, the code doesn't
compile since it can't find `getenv` and `unsetenv`. The fix for this is
to include `cstdlib`.