### PR TITLE
Fix build with GCC 12 (missing <time.h> include)

### DIFF
--- a/src/Toolbar.cc
+++ b/src/Toolbar.cc
@@ -38,6 +38,7 @@
 #include <X11/Xutil.h>
 #include <sys/time.h>
 #include <assert.h>
+#include <time.h>
 
 
 long nextTimeout(int resolution)


### PR DESCRIPTION
Fixes build failure with GCC 12:
```
Toolbar.cc: In member function ‘void Toolbar::reconfigure()’:
Toolbar.cc:260:17: error: ‘time’ was not declared in this scope; did you mean ‘Time’?
  260 |   time_t ttmp = time(NULL);
      |                 ^~~~
      |                 Time
Toolbar.cc:265:21: error: ‘localtime’ was not declared in this scope; did you mean ‘clock_timer’?
  265 |     struct tm *tt = localtime(&ttmp);
      |                     ^~~~~~~~~
      |                     clock_timer
```

Bug: https://bugs.gentoo.org/851603